### PR TITLE
Bump up VK API version and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,12 @@ Python script for dumping vk user's albums
 
 Script has been created for personal purposes, but may someone find this helpful
 
-#### Usage
-Just fill corresponding fields in *config.py* and then run *downloadAlbums.py*
+### Usage
+Just fill corresponding fields in *config.py* file and then run `downloadAlbums.py` using python3
+#### Configuration
+* *OUT*:
+The script will dump albums to the folder specified by this path
+* *ACCESS_TOKEN*:
+The vk API access token string that can be retrieved using a service such as https://vkhost.github.io/. Example: `e3b00314ac44298fc852b855b17077128418c149afbf46fb92427afbe84e41e4649b934ca495991b7c899`
+* *UIDS*:
+The list of vk ids to dump albums from. Example: `id12345678`

--- a/downloadAlbums.py
+++ b/downloadAlbums.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse
 import logging
 from pprint import pprint
 from vkapi import VkApi
-
+from pathvalidate import sanitize_filename
 import config
 
 def getPhotoUrls(photos):
@@ -37,7 +37,8 @@ for user in users:
     print('%s (%d) - %d albums' % (userName, userId, len(albums)))
 
     for album in albums:
-        outDir = '%s/%s (%d)/%s' % (config.OUT, userName, userId, album['title'] + ' (' + str(album['id']) + ')')
+        sanitized_album_title = sanitize_filename(album['title'])
+        outDir = '%s/%s (%d)/%s' % (config.OUT, userName, userId, sanitized_album_title + ' (' + str(album['id']) + ')')
 
         print('    "%s" - %d photos' % (album['title'], album['size']))
 

--- a/downloadAlbums.py
+++ b/downloadAlbums.py
@@ -1,5 +1,6 @@
 import os
 import urllib.request
+from urllib.parse import urlparse
 import logging
 from pprint import pprint
 from vkapi import VkApi
@@ -18,7 +19,7 @@ def downloadPhotos(outDir, urls):
         os.makedirs(outDir)
         
     for photoUrl in urls:
-        file = '%s/%s' % (outDir, photoUrl.rsplit('/', 1)[-1])
+        file = '%s/%s' % (outDir, os.path.basename(urlparse(photoUrl).path))
         if not os.path.exists(file):
             print('        ',  photoUrl)
             urllib.request.urlretrieve(photoUrl, file)

--- a/downloadAlbums.py
+++ b/downloadAlbums.py
@@ -10,8 +10,8 @@ import config
 def getPhotoUrls(photos):
     photoUrls = []
     for photoItem in photos:
-        maxAvailSize = max([int(x.split('_')[1]) for x in photoItem.keys() if x.startswith("photo_")])
-        photoUrls.append(photoItem['photo_' + str(maxAvailSize)])
+        sizes = photoItem['sizes']
+        photoUrls.append(sizes[-1]['url'])
     return photoUrls
 
 def downloadPhotos(outDir, urls):

--- a/vkapi.py
+++ b/vkapi.py
@@ -13,7 +13,7 @@ class VkApi:
     
     TOO_MANY_REQ_PER_SECOND_ERR = 6
     API_URL    = "https://api.vk.com/method/"
-    API_VER    = "5.52"
+    API_VER    = "5.81"
 
     def __init__(self, access_token = None):
         """ Constructor


### PR DESCRIPTION
Current vk api version is outdated and such requests are blocked with following error message: `'Invalid request: versions below 5.81 are deprecated. Version param should be passed as "v". "version" param is invalid and not supported. For more information go to https://vk.com/dev/constant_version_updates'`

This PR bumps up vk api version to v5.81 and adjusts code to new API.
Also extends readme file with a configuration fields description.